### PR TITLE
Add %parse-param and %lex-param directives

### DIFF
--- a/src/bison.bnf
+++ b/src/bison.bnf
@@ -32,6 +32,8 @@ prologue_declaration ::= prologue
            | '%no-lines'
            | '%nondeterministic-parser'
            | '%param' braced_code+
+           | '%parse-param' braced_code+
+           | '%lex-param' braced_code+
            | '%pure-parser'
            | '%token-table'
            | '%verbose'


### PR DESCRIPTION
%lex-param and %parse-param have the same syntax as %param